### PR TITLE
Add Things3 companion skeleton

### DIFF
--- a/things3-companion/LICENSE
+++ b/things3-companion/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/things3-companion/README.md
+++ b/things3-companion/README.md
@@ -1,0 +1,18 @@
+# Things3 Companion (Personal)
+
+This repository contains a proof-of-concept Android companion app and supporting infrastructure for integrating with **Things3**, a proprietary task management application by Cultured Code.
+
+**Crucial Legal Disclaimer:** This project interacts with Things3's internal database through unofficial means. Cultured Code warns that direct database access can corrupt data. There is no public API. This repository is provided for **personal, non‑commercial** experimentation only. Distributing or commercializing any derivative application may violate Cultured Code's EULA, Terms of Service, and various intellectual property rights. Consult legal counsel before considering public use.
+
+## Repository Structure
+
+- `android-app/` – Kotlin/Jetpack Compose Android application skeleton.
+- `ec2-server/` – Scripts and instructions for running the read-only GraphQL API and webhook handler on an AWS EC2 instance.
+- `apple-automation/` – Apple Shortcut and iPad automation instructions used to create tasks in Things3.
+- `third-party-automation/` – Setup notes for bridging webhook services (Zapier/IFTTT).
+
+Each directory includes a README with setup details.
+
+## License
+
+The custom code in this repository is released under the MIT License. The external `evelion-apps/things-api` project is GPLv3 and must be obtained separately.

--- a/things3-companion/android-app/README.md
+++ b/things3-companion/android-app/README.md
@@ -1,0 +1,7 @@
+# Android App
+
+This directory contains a minimal Android application written in Kotlin using Jetpack Compose. It is intended to query a read-only GraphQL API hosted on your EC2 instance and to send webhook requests for task creation.
+
+The project skeleton can be opened with Android Studio. Update the API endpoint and webhook URL within the code or a configuration screen.
+
+Run the app using a Pixel 8 Pro emulator or device.

--- a/things3-companion/android-app/app/build.gradle.kts
+++ b/things3-companion/android-app/app/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.things3companion"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.things3companion"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+        }
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.compose.material3:material3:1.1.2")
+    // Apollo Kotlin for GraphQL
+    implementation("com.apollographql.apollo3:apollo-runtime:3.8.2")
+    // Retrofit/OkHttp for HTTP requests
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
+    // Moshi for JSON parsing
+    implementation("com.squareup.moshi:moshi:1.15.0")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
+    kapt("com.squareup.moshi:moshi-kotlin-codegen:1.15.0")
+}

--- a/things3-companion/android-app/app/src/main/AndroidManifest.xml
+++ b/things3-companion/android-app/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.things3companion">
+
+    <application
+        android:label="Things3 Companion"
+        android:icon="@mipmap/ic_launcher"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/things3-companion/android-app/app/src/main/java/com/example/things3companion/MainActivity.kt
+++ b/things3-companion/android-app/app/src/main/java/com/example/things3companion/MainActivity.kt
@@ -1,0 +1,34 @@
+package com.example.things3companion
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface {
+                    Greeting("Things3")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun Greeting(name: String) {
+    Text(text = "Hello $name")
+}
+
+@Preview
+@Composable
+fun GreetingPreview() {
+    Greeting("Android")
+}

--- a/things3-companion/android-app/build.gradle
+++ b/things3-companion/android-app/build.gradle
@@ -1,0 +1,18 @@
+// Top-level Gradle build file
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/things3-companion/apple-automation/README.md
+++ b/things3-companion/apple-automation/README.md
@@ -1,0 +1,5 @@
+# Apple Automation
+
+This directory documents the setup for running an Apple Shortcut on a dedicated iPad Pro to create tasks in Things3.
+
+The file `Things3_CreateTask_Shortcut.shortcut` is an exported Shortcut that expects a JSON string as input. Import it on the iPad and enable "Run Without Asking" if desired.

--- a/things3-companion/apple-automation/setup_ipad_automation.md
+++ b/things3-companion/apple-automation/setup_ipad_automation.md
@@ -1,0 +1,6 @@
+# iPad Automation Setup
+
+1. Enable **Things URLs** in Things3 settings and copy your auth token.
+2. Import the `Things3_CreateTask_Shortcut.shortcut` into the Shortcuts app and edit it to include your auth token when constructing the URL scheme.
+3. Ensure the Shortcut is named `CreateThingsTask` and accepts a JSON dictionary via the `Get Dictionary from Input` action.
+4. Configure an SSH server or alternative trigger so the EC2 instance can remotely run this Shortcut.

--- a/things3-companion/ec2-server/README.md
+++ b/things3-companion/ec2-server/README.md
@@ -1,0 +1,9 @@
+# EC2 Server Setup
+
+This directory contains scripts and instructions to configure an AWS EC2 instance that hosts a read-only GraphQL API for Things3 and a webhook handler to trigger iPad automation.
+
+## Overview
+
+1. `evelion-apps-things-api/` – placeholder for the API code (clone from GitHub).
+2. `setup-scripts/` – shell scripts to install dependencies and configure the API server.
+3. `webhook-handler/` – simple Python server that receives webhook requests and triggers an Apple Shortcut via SSH.

--- a/things3-companion/ec2-server/evelion-apps-things-api/README.md
+++ b/things3-companion/ec2-server/evelion-apps-things-api/README.md
@@ -1,0 +1,7 @@
+This directory is a placeholder. Clone the official `evelion-apps/things-api` repository here:
+
+```bash
+git clone https://github.com/evelion-apps/things-api.git .
+```
+
+The project is licensed under GPLv3.

--- a/things3-companion/ec2-server/setup-scripts/README.md
+++ b/things3-companion/ec2-server/setup-scripts/README.md
@@ -1,0 +1,7 @@
+# Setup Scripts
+
+These scripts assist with configuring the EC2 instance for the Things3 read-only API.
+
+- `install_ruby_sqlite_ubuntu.sh` – installs Ruby, SQLite, and build tools.
+- `configure_api_server.sh` – clones and prepares the `evelion-apps/things-api` project.
+- `configure_ssh_mac_to_ec2.sh` – helper script for setting up passwordless SSH from macOS to EC2.

--- a/things3-companion/ec2-server/setup-scripts/configure_api_server.sh
+++ b/things3-companion/ec2-server/setup-scripts/configure_api_server.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+REPO_DIR="$HOME/evelion-apps-things-api"
+if [ ! -d "$REPO_DIR" ]; then
+    git clone https://github.com/evelion-apps/things-api.git "$REPO_DIR"
+fi
+cd "$REPO_DIR"
+cp .env.local.example .env.local
+# Update SYNC_DB_* variables as needed
+bin/install

--- a/things3-companion/ec2-server/setup-scripts/configure_ssh_mac_to_ec2.sh
+++ b/things3-companion/ec2-server/setup-scripts/configure_ssh_mac_to_ec2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Run on macOS to set up passwordless SSH to the EC2 instance.
+# Usage: ./configure_ssh_mac_to_ec2.sh user@ec2-host
+
+KEY=~/.ssh/things3_ec2
+ssh-keygen -t rsa -b 4096 -f "$KEY" -N ""
+ssh-copy-id -i "$KEY" "$1"

--- a/things3-companion/ec2-server/setup-scripts/install_ruby_sqlite_ubuntu.sh
+++ b/things3-companion/ec2-server/setup-scripts/install_ruby_sqlite_ubuntu.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+sudo apt-get update
+sudo apt-get install -y build-essential libsqlite3-dev ruby-full git

--- a/things3-companion/ec2-server/webhook-handler/README.md
+++ b/things3-companion/ec2-server/webhook-handler/README.md
@@ -1,0 +1,18 @@
+# Webhook Handler
+
+A minimal Flask server that receives POST requests from Zapier or IFTTT and triggers an Apple Shortcut on a dedicated iPad via SSH.
+
+Set the following environment variables before running:
+
+- `IPAD_HOST` – iPad hostname or IP address
+- `IPAD_USER` – SSH username
+- `SSH_KEY` – path to the private key for authentication
+
+Run the server:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python server.py
+```

--- a/things3-companion/ec2-server/webhook-handler/requirements.txt
+++ b/things3-companion/ec2-server/webhook-handler/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+paramiko

--- a/things3-companion/ec2-server/webhook-handler/server.py
+++ b/things3-companion/ec2-server/webhook-handler/server.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify
+import paramiko
+import os
+
+app = Flask(__name__)
+
+IPAD_HOST = os.environ.get("IPAD_HOST")
+IPAD_USER = os.environ.get("IPAD_USER")
+SSH_KEY = os.environ.get("SSH_KEY")
+SHORTCUT_NAME = "CreateThingsTask"
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': 'invalid payload'}), 400
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.connect(IPAD_HOST, username=IPAD_USER, key_filename=SSH_KEY)
+    payload = json.dumps(data)
+    cmd = f"shortcuts://run-shortcut?name={SHORTCUT_NAME}&input=text&text={payload}"
+    ssh.exec_command(f"open '{cmd}'")
+    ssh.close()
+    return jsonify({'status': 'triggered'})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/things3-companion/third-party-automation/zapier-ifttt-setup.md
+++ b/things3-companion/third-party-automation/zapier-ifttt-setup.md
@@ -1,0 +1,6 @@
+# Zapier/IFTTT Setup
+
+1. Create an account on [Zapier](https://zapier.com) or [IFTTT](https://ifttt.com).
+2. Create a new Zap/Applet with a **Webhooks** trigger. Choose the option to receive a JSON payload via POST.
+3. Copy the generated webhook URL and configure the Android app to send POST requests to it.
+4. Add an action to forward this JSON payload to your EC2 webhook handler endpoint (e.g., `http://YOUR_EC2_IP:5000/webhook`).


### PR DESCRIPTION
## Summary
- add initial README with legal disclaimer
- add skeleton Android app using Kotlin/Compose
- add EC2 server scripts and webhook handler
- add Apple Shortcut placeholder and automation docs
- add third-party automation instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842cf10e6d08322836e169f59e6853b